### PR TITLE
Patched a server-side crash

### DIFF
--- a/src/main/java/com/zeml/rotp_zhp/entity/damaging/projectile/HPGrapplingVineEntity.java
+++ b/src/main/java/com/zeml/rotp_zhp/entity/damaging/projectile/HPGrapplingVineEntity.java
@@ -316,16 +316,30 @@ import java.util.UUID;
         }
 
         @Override
-        public void writeSpawnData(PacketBuffer buffer){
-            super.writeSpawnData(buffer);
-            buffer.writeUUID(userU);
+        protected void addAdditionalSaveData(CompoundNBT nbt) {
+            super.addAdditionalSaveData(nbt);
+            if (this.userU != null) {
+                nbt.putUUID("UserServerId", this.userU);
+            }
         }
 
         @Override
-        public void readSpawnData(PacketBuffer additionalData) {
-            super.readSpawnData(additionalData);
-            this.userU = additionalData.readUUID();
+        protected void readAdditionalSaveData(CompoundNBT nbt) {
+            super.readAdditionalSaveData(nbt);
+            if (nbt.hasUUID("UserServerId")) {
+                this.userU = nbt.getUUID("UserServerId");
+            }
         }
+
+        // @Override
+        // public void writeSpawnData(PacketBuffer buffer){
+        //     super.writeSpawnData(buffer);
+        // }
+
+        // @Override
+        // public void readSpawnData(PacketBuffer additionalData) {
+        //     super.readSpawnData(additionalData);
+        // }
 
         public void isCharged(boolean charg){
             this.ischarge=charg;


### PR DESCRIPTION
The crash occurs when shooting a grappling vine at a Nether portal, when there is a player on the other side. It seems like the cause is that the `userU` field isn't saved in NBT, causing it to become null after the game serializes and then deserializes the entity in order to add it to another dimension. `userU` doesn't seem to be used on the client side (hurtTarget is only called on server), so it doesn't need to be synced anyway.